### PR TITLE
Fix broken main + consolidate CSS + deploy tooling

### DIFF
--- a/app.css
+++ b/app.css
@@ -1,0 +1,2505 @@
+/* ============================================================================
+   audiolibri.org — app.css
+   Single consolidated stylesheet. Replaces: styles.css, tailwind-styles.css,
+   mobile-navigation.css, mobile-fixes.css, dynamic-components.css,
+   tailwind-mobile.css, tailwind-grid-components.css, tailwind-nav-components.css,
+   tailwind-modern-ios.css.
+
+   Sections:
+     1. Design tokens (scale: space / type / radius / shadow / motion)
+     2. Utilities (the load-bearing tw-/pill set, defined once)
+     3. Components & base  (proven rules, color tokens live here)
+     4. Mobile overrides
+     5. iOS safe-area helpers
+   Color tokens (--primary-color, --text-color, …) are defined in §3 and
+   themed via prefers-color-scheme.
+   ============================================================================ */
+
+/* ── 1. Design tokens ───────────────────────────────────────────────────── */
+:root {
+    /* Spacing scale */
+    --space-1: 0.25rem;
+    --space-2: 0.5rem;
+    --space-3: 0.75rem;
+    --space-4: 1rem;
+    --space-5: 1.25rem;
+    --space-6: 1.5rem;
+    --space-8: 2rem;
+    --space-10: 2.5rem;
+    --space-12: 3rem;
+
+    /* Type scale */
+    --text-xs: 0.75rem;
+    --text-sm: 0.875rem;
+    --text-base: 1rem;
+    --text-lg: 1.125rem;
+    --text-xl: 1.25rem;
+    --text-2xl: 1.5rem;
+    --text-3xl: 1.8rem;
+    --leading-tight: 1.3;
+    --leading-normal: 1.6;
+
+    /* Radius scale */
+    --radius-sm: 0.5rem;
+    --radius-md: 0.75rem;
+    --radius-lg: 1rem;
+    --radius-xl: 1.25rem;
+    --radius-pill: 9999px;
+
+    /* Elevation */
+    --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+    --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+
+    /* Motion */
+    --dur-fast: 0.15s;
+    --dur: 0.2s;
+    --dur-slow: 0.3s;
+    --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+
+    /* Typography family (display family reserved for a later phase) */
+    --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+
+    /* Layout */
+    --max-width: 1200px;
+}
+
+/* ── 2. Utilities (load-bearing set only — defined once) ────────────────────
+   These are the only tw-*/pill utilities actually referenced by the markup
+   and app.js. Previously-undefined utility classes in the HTML (e.g. tw-px-4,
+   tw-min-h-[…], sm:tw-*) were no-ops without a build step and are intentionally
+   left undefined — their visual effect already comes from semantic selectors. */
+
+/* layout */
+.tw-container { width: 100%; max-width: var(--max-width); margin-left: auto; margin-right: auto; padding: var(--space-8); }
+.tw-flex { display: flex; }
+.tw-flex-col { flex-direction: column; }
+.tw-grid { display: grid; }
+.tw-items-center { align-items: center; }
+.tw-justify-center { justify-content: center; }
+
+/* spacing */
+.tw-gap-2 { gap: var(--space-2); }
+.tw-gap-3 { gap: var(--space-3); }
+.tw-gap-4 { gap: var(--space-4); }
+.tw-gap-6 { gap: var(--space-6); }
+.tw-mb-2 { margin-bottom: var(--space-2); }
+.tw-mb-4 { margin-bottom: var(--space-4); }
+.tw-mb-6 { margin-bottom: var(--space-6); }
+.tw-mt-2 { margin-top: var(--space-2); }
+
+/* type */
+.tw-text-center { text-align: center; }
+.tw-text-sm { font-size: var(--text-sm); }
+.tw-text-base { font-size: var(--text-base); }
+.tw-text-lg { font-size: var(--text-lg); }
+.tw-font-medium { font-weight: 500; }
+.tw-font-semibold { font-weight: 600; }
+
+/* radius */
+.tw-rounded-full { border-radius: var(--radius-pill); }
+
+/* component utilities (mirror the proven semantic rules; kept because the
+   markup applies these class names alongside semantic ones) */
+.tw-card {
+    background-color: var(--card-background);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--card-shadow);
+    margin-bottom: var(--space-8);
+    overflow: hidden;
+    border: 1px solid var(--border-color);
+}
+.tw-button {
+    padding: 0.875rem var(--space-5);
+    border-radius: var(--radius-pill);
+    border: none;
+    background-color: var(--primary-color);
+    color: white;
+    cursor: pointer;
+    font-size: var(--text-base);
+    font-weight: 500;
+    font-family: inherit;
+    transition: all var(--dur) ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    line-height: 1;
+}
+.tw-button:hover { background-color: var(--primary-hover); transform: translateY(-2px); box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); }
+.tw-button:active { transform: translateY(0); }
+.tw-input {
+    padding: 0.875rem var(--space-5);
+    width: 100%;
+    border-radius: var(--radius-pill);
+    border: 1px solid var(--search-border);
+    font-size: var(--text-base);
+    font-family: inherit;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.03);
+    transition: all 0.25s ease;
+    background-color: var(--card-background);
+    color: var(--text-color);
+}
+.tw-input:focus { outline: none; border-color: var(--primary-color); box-shadow: 0 0 0 3px rgba(74, 108, 247, 0.15); }
+
+/* pill nav (genre-style pills built by app.js) */
+.tw-pill {
+    display: inline-flex;
+    align-items: center;
+    white-space: nowrap;
+    padding: 0.375rem var(--space-3);
+    border-radius: var(--radius-pill);
+    background-color: var(--tag-bg, #e2e8f0);
+    color: var(--tag-text, #4a5568);
+    font-size: var(--text-xs);
+    font-weight: 500;
+    cursor: pointer;
+    user-select: none;
+    transition: background-color var(--dur) ease, transform 0.1s ease;
+}
+.tw-pill:active { transform: scale(0.95); }
+.tw-pill.active { background-color: var(--primary-color, #4a6cf7); color: white; }
+
+/* mobile search input + horizontal scroller */
+.tw-mobile-input {
+    height: 48px;
+    width: 100%;
+    padding: 0 12px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-color, #e5e7eb);
+    font-size: 16px;
+    background-color: var(--card-background, #ffffff);
+}
+.tw-mobile-scroll {
+    display: flex;
+    overflow-x: auto;
+    padding-bottom: 12px;
+    margin: 0 -8px;
+    padding-left: 8px;
+    padding-right: 8px;
+    scroll-snap-type: x mandatory;
+    scroll-behavior: smooth;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+}
+.tw-mobile-scroll::-webkit-scrollbar { display: none; }
+.tw-mobile-scroll-item { scroll-snap-align: start; flex-shrink: 0; width: 160px; margin-right: 12px; }
+@media (min-width: 640px) {
+    .tw-mobile-scroll-item { width: 192px; }
+}
+
+/* ── 3. Components & base (color tokens defined here, themed below) ───────── */
+/* styles.css */
+
+/* WCAG 2.1 AA Compliance Styles */
+
+/* Skip Link for Screen Readers */
+.skip-link {
+    position: absolute;
+    top: -40px;
+    left: 6px;
+    background: var(--primary-color);
+    color: white;
+    padding: 8px 16px;
+    text-decoration: none;
+    border-radius: 4px;
+    font-weight: 600;
+    z-index: 1000;
+    transition: top 0.3s;
+}
+
+.skip-link:focus {
+    top: 6px;
+}
+
+/* Screen Reader Only Text */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+/* Enhanced Focus Indicators - WCAG 2.1 AA compliant */
+*:focus {
+    outline: 3px solid var(--focus-ring-light);
+    outline-offset: 2px;
+}
+
+/* CSS Variables for RGB values */
+:root {
+    --primary-rgb: 74, 108, 247;
+    --accent-rgb: 16, 185, 129;
+    --card-background-rgb: 255, 255, 255;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --primary-rgb: 252, 134, 134;
+        --accent-rgb: 3, 218, 198;
+        --card-background-rgb: 18, 18, 18;
+    }
+}
+
+/* Prevent FOUC */
+body {
+    visibility: visible;
+}
+
+/* High contrast focus for dark mode */
+@media (prefers-color-scheme: dark) {
+    *:focus {
+        outline-color: var(--focus-ring-dark);
+    }
+}
+
+/* Remove default focus for mouse users but keep for keyboard */
+*:focus:not(:focus-visible) {
+    outline: none;
+}
+
+*:focus-visible {
+    outline: 3px solid var(--focus-ring-light);
+    outline-offset: 2px;
+}
+
+@media (prefers-color-scheme: dark) {
+    *:focus-visible {
+        outline-color: var(--focus-ring-dark);
+    }
+}
+
+/* Ensure minimum 44px touch targets on mobile */
+@media (max-width: 768px) {
+    button, a, input, [role="button"] {
+        min-height: 44px;
+        min-width: 44px;
+    }
+}
+
+/* Enhanced color contrast ratios */
+:root {
+    /* Light theme colors - Enhanced for WCAG AA contrast */
+    --background-color: #f5f7fa;
+    --text-color: #1a202c; /* Darker for better contrast */
+    --card-background: #ffffff;
+    --card-shadow: 0 10px 25px rgba(0,0,0,0.05);
+    --border-color: #e2e8f0;
+    --primary-color: #3b51d4; /* Darker for better contrast */
+    --primary-hover: #2a3cb8;
+    --accent-color: #047857; /* Darker green for better contrast */
+    --accent-hover: #065f46;
+    --danger-color: #dc2626; /* Better contrast red */
+    --danger-hover: #b91c1c;
+    --header-color: #111827; /* Much darker for better contrast */
+    --secondary-text: #4b5563; /* Darker for better contrast */
+    --placeholder-bg: #f8fafc;
+    --meta-background: rgba(0, 0, 0, 0.75); /* Higher opacity for readability */
+    --search-border: #9ca3af; /* Darker border for visibility */
+    --disabled-button: #9ca3af; /* Darker for better contrast */
+    --loading-color: #3b51d4;
+    --tag-bg: #d1d5db; /* Darker background */
+    --tag-text: #374151; /* Darker text */
+    --hover-overlay: rgba(0, 0, 0, 0.05);
+    --progress-bg: #e5e7eb;
+    --progress-fill: #3b51d4;
+    
+    /* Enhanced focus colors */
+    --focus-ring-light: #3b51d4;
+    --focus-ring-dark: #10b981;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        /* Dark theme colors - Enhanced for WCAG AA contrast */
+        --background-color: #000000;
+        --text-color: #f1f5f9; /* Brighter for better contrast */
+        --card-background: #121212;
+        --card-shadow: 0 10px 25px rgba(0,0,0,0.4);
+        --border-color: #404040; /* Lighter border for visibility */
+        --primary-color: #ff6b6b; /* Better contrast red */
+        --primary-hover: #ff5252;
+        --accent-color: #4ecdc4; /* Better contrast cyan */
+        --accent-hover: #26a69a;
+        --danger-color: #ff5252;
+        --danger-hover: #f44336;
+        --header-color: #ffffff;
+        --secondary-text: #b3b3b3; /* Lighter for better contrast */
+        --placeholder-bg: #1e1e1e;
+        --meta-background: rgba(0, 0, 0, 0.85); /* Higher opacity for readability */
+        --search-border: #525252; /* Lighter border */
+        --disabled-button: #525252; /* Better contrast */
+        --hover-overlay: rgba(255, 255, 255, 0.08);
+        --tag-bg: #404040; /* Lighter background */
+        --tag-text: #f1f5f9; /* Brighter text */
+        --progress-bg: #404040;
+        --progress-fill: #4ecdc4;
+        
+        /* Enhanced focus colors for dark mode */
+        --focus-ring-light: #ff6b6b;
+        --focus-ring-dark: #4ecdc4;
+    }
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: var(--font-sans);
+    background-color: var(--background-color);
+    margin: 0;
+    padding: 0;
+    color: var(--text-color);
+    line-height: var(--leading-normal);
+    font-size: var(--text-base);
+    transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem;
+}
+
+/* Header card redesign */
+header {
+    text-align: center;
+    margin-bottom: 2.5rem;
+    border-radius: 16px;
+    box-shadow: var(--card-shadow);
+    padding: 2rem;
+    border: 0px solid var(--border-color);
+    position: relative;
+    overflow: hidden;
+    isolation: isolate;
+}
+
+header::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: linear-gradient(135deg, 
+                rgba(var(--primary-rgb), 0.08) 0%, 
+                rgba(var(--card-background-rgb), 1) 50%,
+                rgba(var(--accent-rgb), 0.08) 100%);
+    z-index: -1;
+}
+
+/* Enhanced title styling */
+.site-title-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-bottom: 1.5rem;
+}
+
+h1 {
+    color: var(--header-color);
+    font-size: 2rem;
+    letter-spacing: -0.025em;
+    font-weight: 800;
+    margin: 0 0 0.5rem;
+    position: relative;
+    display: inline-block;
+    background: linear-gradient(90deg, var(--primary-color) 0%, var(--accent-color) 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    /* Fallback for browsers that don't support text-fill-color */
+    color: transparent;
+}
+
+.title-icon {
+    margin-bottom: 0.75rem;
+    font-size: 2rem;
+    animation: pulse 2s infinite ease-in-out;
+}
+
+.site-tagline {
+    color: var(--secondary-text);
+    font-size: 1.2rem;
+    font-weight: 500;
+    max-width: 600px;
+    margin: 0 auto;
+}
+
+@keyframes pulse {
+    0% { transform: scale(1); opacity: 1; }
+    50% { transform: scale(1.1); opacity: 0.8; }
+    100% { transform: scale(1); opacity: 1; }
+}
+
+/* Library stats styling */
+.library-stats-container {
+    margin-bottom: 1.5rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--border-color);
+    position: relative;
+}
+
+.library-stats-container::after {
+    content: '';
+    position: absolute;
+    bottom: -1px;
+    left: 25%;
+    right: 25%;
+    height: 1px;
+    background: linear-gradient(to right, 
+                transparent 0%, 
+                var(--primary-color) 50%, 
+                transparent 100%);
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1rem;
+}
+
+.stat-item {
+    padding: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
+.stat-value {
+    font-size: 1.8rem;
+    font-weight: bold;
+    color: var(--primary-color);
+    margin-bottom: 0.25rem;
+}
+
+.stat-label {
+    font-size: 0.875rem;
+    color: var(--secondary-text);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 500;
+}
+
+.header-content {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.search-container {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    margin: 0 auto;
+    max-width: 650px;
+    width: 100%;
+}
+
+.navigation-container {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+}
+
+.button-group {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    margin-top: 1.25rem;
+    flex-wrap: wrap;
+}
+
+#search {
+    padding: 0.875rem 1.25rem;
+    width: 100%;
+    border-radius: 9999px;
+    border: 1px solid var(--search-border);
+    font-size: 1rem;
+    font-family: inherit;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.03);
+    transition: all 0.25s ease;
+    background-color: var(--card-background);
+    color: var(--text-color);
+}
+
+#search:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 3px rgba(74, 108, 247, 0.15);
+}
+
+button {
+    padding: 0.875rem 1.25rem;
+    border-radius: 9999px;
+    border: none;
+    background-color: var(--primary-color);
+    color: white;
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: 500;
+    font-family: inherit;
+    transition: all 0.2s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    line-height: 1;
+}
+
+button:hover {
+    background-color: var(--primary-hover);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+}
+
+button:active {
+    transform: translateY(0);
+}
+
+button:disabled {
+    background-color: var(--disabled-button);
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
+    opacity: 0.7;
+}
+
+button:disabled:hover {
+    background-color: var(--disabled-button);
+    transform: none;
+    box-shadow: none;
+}
+
+.single-card {
+    background-color: var(--card-background);
+    border-radius: 16px;
+    box-shadow: var(--card-shadow);
+    margin-bottom: 2rem;
+    overflow: hidden;
+    border: 1px solid var(--border-color);
+}
+
+.audiobook-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    transition: all 0.3s ease;
+    overflow: hidden;
+    min-height: 500px;
+    background-size: cover;
+    background-position: center;
+}
+
+.card-overlay {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.85) 100%);
+    width: 100%;
+    height: 100%;
+    color: white;
+    padding: 2rem;
+    box-sizing: border-box;
+}
+
+@media (min-width: 800px) {
+    .card-overlay {
+        flex-direction: row;
+        align-items: flex-start;
+        gap: 2rem;
+    }
+}
+
+/* Media container and player */
+.media-container {
+    z-index: 3;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    max-width: 320px;
+    margin-bottom: 1.5rem;
+}
+
+#youtube-player {
+    width: 100%;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 8px 16px rgba(0,0,0,0.3);
+    margin-bottom: 1rem;
+    aspect-ratio: 16/9;
+}
+
+.player-controls {
+    background-color: rgba(18, 18, 18, 0.85); /* Darker background for dark theme */
+    backdrop-filter: blur(10px);
+    border-radius: 12px;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.controls-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.5rem;
+}
+
+.progress-container {
+    width: 100%;
+    height: 4px;
+    background-color: var(--progress-bg);
+    border-radius: 2px;
+    margin: 0.5rem 0;
+    position: relative;
+    cursor: pointer;
+}
+
+.progress-bar {
+    height: 100%;
+    background-color: var(--progress-fill);
+    border-radius: 2px;
+    width: 0%;
+    transition: width 0.1s linear;
+}
+
+.progress-handle {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background-color: white;
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    left: 0%;
+    box-shadow: 0 0 4px rgba(0,0,0,0.5);
+    cursor: pointer;
+}
+
+.time-display {
+    color: white;
+    font-size: 0.75rem;
+    font-variant-numeric: tabular-nums;
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+}
+
+.control-button {
+    background-color: rgba(255, 255, 255, 0.15);
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    color: white;
+    padding: 0;
+    border: none;
+}
+
+.control-button:hover {
+    background-color: rgba(255, 255, 255, 0.25);
+    transform: scale(1.05);
+    box-shadow: none;
+}
+
+.control-button.large {
+    width: 50px;
+    height: 50px;
+}
+
+.volume-control {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+}
+
+#volume-slider {
+    width: 100%;
+    height: 4px;
+    appearance: none;
+    background: rgba(255, 255, 255, 0.2);
+    border-radius: 2px;
+    outline: none;
+}
+
+#volume-slider::-webkit-slider-thumb {
+    appearance: none;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: white;
+    cursor: pointer;
+}
+
+/* Icons */
+.play-icon::before {
+    content: "▶";
+}
+
+.pause-icon::before {
+    content: "⏸";
+}
+
+.volume-icon::before {
+    content: "🔊";
+    font-size: 16px;
+}
+
+.rewind-icon::before {
+    content: "⏪";
+    font-size: 14px;
+}
+
+.forward-icon::before {
+    content: "⏩";
+    font-size: 14px;
+}
+
+.error-icon {
+    display: inline-block;
+    width: 24px;
+    height: 24px;
+    background-color: var(--danger-color);
+    color: white;
+    border-radius: 50%;
+    text-align: center;
+    line-height: 24px;
+    margin-right: 8px;
+    font-style: normal;
+    font-weight: bold;
+}
+
+.time-icon::before {
+    content: "⏱";
+    margin-right: 5px;
+}
+
+.audio-icon::before {
+    content: "🎧";
+    margin-right: 5px;
+}
+
+/* Book details */
+.book-details {
+    flex: 1;
+    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.book-text-content {
+    background-color: rgba(0, 0, 0, 0.75);
+    padding: 1.75rem;
+    border-radius: 12px;
+    margin-bottom: 0;
+    backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.book-details h2 {
+    color: white;
+    margin-top: 0;
+    font-size: 1.75rem;
+    text-shadow: 1px 1px 3px rgba(0,0,0,0.5);
+    letter-spacing: -0.025em;
+    line-height: 1.3;
+    margin-bottom: 0.5rem;
+}
+
+.book-details h3 {
+    color: rgba(255, 255, 255, 0.9);
+    font-weight: 500;
+    margin-top: 0;
+    text-shadow: 1px 1px 2px rgba(0,0,0,0.5);
+    font-size: 1.125rem;
+    margin-bottom: 0.75rem;
+}
+
+.book-details p {
+    line-height: 1.6;
+    color: rgba(255, 255, 255, 0.95);
+    text-shadow: 0px 1px 2px rgba(0,0,0,0.7);
+    font-size: 1rem;
+    margin-bottom: 1rem;
+}
+
+.book-categories {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+.category-tag {
+    background-color: rgba(255, 255, 255, 0.15);
+    color: white;
+    padding: 0.25rem 0.75rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 500;
+}
+
+#audio-player {
+    width: 100%;
+    margin-top: 1rem;
+    border-radius: 8px;
+    height: 36px;
+}
+
+.meta-inline {
+    margin-top: 1.25rem;
+    font-size: 0.875rem;
+    color: white;
+    border-top: 1px solid rgba(255, 255, 255, 0.15);
+    padding-top: 1.25rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.meta-item {
+    display: flex;
+    align-items: center;
+    margin-bottom: 0.5rem;
+    color: #c4c4c4;
+}
+
+.duration-badge {
+    display: inline-flex;
+    align-items: center;
+    background-color: rgba(255, 255, 255, 0.2);
+    padding: 0.25rem 0.75rem;
+    border-radius: 9999px;
+    margin-left: 0.5rem;
+    transition: all 0.2s ease;
+    font-weight: 500;
+    font-size: 0.875rem;
+}
+
+.audio-status.available {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.375rem 0.75rem;
+    border-radius: 9999px;
+    font-size: 0.875rem;
+    margin-bottom: 0.75rem;
+    font-weight: 500;
+    background-color: var(--accent-color);
+    color: white;
+}
+
+.channel-link {
+    display: inline-flex;
+    align-items: center;
+    background-color: rgba(255, 255, 255, 0.15);
+    padding: 0.25rem 0.75rem;
+    border-radius: 9999px;
+    margin-left: 0.25rem;
+    transition: all 0.2s ease;
+    text-decoration: none;
+    color: white;
+}
+
+.channel-link:hover {
+    background-color: rgba(255, 255, 255, 0.25);
+    text-decoration: none;
+    color: white;
+}
+
+.channel-link .channel-icon {
+    width: 18px;
+    height: 18px;
+    margin-right: 0.5rem;
+}
+
+/* Loading states */
+.loading-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    height: 500px;
+    color: var(--text-color);
+    background-color: var(--card-background);
+    border-radius: 16px;
+    padding: 2rem;
+}
+
+.loading-spinner {
+    width: 50px;
+    height: 50px;
+    border: 4px solid rgba(0, 0, 0, 0.1);
+    border-radius: 50%;
+    border-top-color: var(--primary-color);
+    animation: spin 1s ease-in-out infinite;
+    margin-bottom: 1.5rem;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+.error-message, .no-results {
+    padding: 3rem 2rem;
+    text-align: center;
+    border-radius: 12px;
+    margin: 1rem 0;
+}
+
+.error-message {
+    color: var(--danger-color);
+    background-color: rgba(239, 68, 68, 0.1);
+    font-weight: 500;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+}
+
+.no-results {
+    color: var(--text-color);
+    background-color: rgba(255, 255, 255, 0.05);
+    font-weight: 500;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+}
+
+.search-icon::before {
+    content: "🔍";
+    font-size: 32px;
+    display: block;
+}
+
+.book-placeholder {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    height: 400px;
+    color: var(--secondary-text);
+    text-align: center;
+    font-size: 1.125rem;
+    background-color: var(--placeholder-bg);
+    border-radius: 12px;
+    gap: 1rem;
+}
+
+.book-placeholder-icon {
+    font-size: 3rem;
+    margin-bottom: 1rem;
+    color: var(--primary-color);
+    opacity: 0.5;
+}
+
+/* Footer */
+footer {
+    text-align: center;
+    margin-top: 3rem;
+    padding-top: 2rem;
+    padding-bottom: 2rem;
+    color: var(--secondary-text);
+    border-top: 1px solid var(--border-color);
+    font-size: 0.875rem;
+    background: linear-gradient(to top, rgba(var(--primary-rgb), 0.02), transparent);
+}
+
+.footer-actions {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
+}
+
+.footer-links {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin-bottom: 1rem;
+}
+
+.footer-link {
+    text-decoration: none;
+    font-weight: 500;
+    letter-spacing: 0.01em;
+    position: relative;
+}
+
+.footer-link::after {
+    content: '';
+    position: absolute;
+    bottom: -2px;
+    left: 0;
+    width: 0;
+    height: 2px;
+    background-color: var(--primary-color);
+    transition: width 0.2s ease;
+}
+
+.footer-link:hover::after {
+    width: 100%;
+}
+
+.footer-info {
+    line-height: 1.6;
+}
+
+.footer-info p {
+    margin: 0.5rem 0;
+}
+
+#theme-toggle {
+    background-color: transparent;
+    color: var(--text-color);
+    border: 1px solid var(--border-color);
+    padding: 0.5rem 1rem;
+    font-size: 0.875rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    font-weight: 500;
+}
+
+#theme-toggle:hover {
+    background-color: var(--hover-overlay);
+    transform: translateY(-1px);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.theme-icon {
+    font-size: 1rem;
+    transition: transform 0.2s ease;
+}
+
+#theme-toggle:hover .theme-icon {
+    transform: rotate(180deg);
+}
+
+.source-code-link {
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.source-code-link:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+@media (max-width: 640px) {
+    footer {
+        margin-top: 2rem;
+        padding-top: 1.5rem;
+        font-size: 0.8125rem;
+    }
+    
+    .footer-links {
+        gap: 1rem;
+    }
+    
+    .footer-info p {
+        margin: 0.375rem 0;
+    }
+}
+
+/* EN 301 549 European Accessibility Standard Styles */
+
+/* Session Timeout Warning Dialog */
+.session-timeout-warning {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10000;
+    padding: 1rem;
+}
+
+.timeout-content {
+    background-color: var(--card-background);
+    color: var(--text-color);
+    border-radius: 8px;
+    padding: 2rem;
+    max-width: 400px;
+    width: 100%;
+    text-align: center;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    border: 2px solid var(--primary-color);
+}
+
+.timeout-content h3 {
+    margin-bottom: 1rem;
+    color: var(--header-color);
+    font-size: 1.25rem;
+}
+
+.timeout-content p {
+    margin-bottom: 1.5rem;
+    line-height: 1.5;
+}
+
+.extend-session-btn,
+.dismiss-btn {
+    background-color: var(--primary-color);
+    color: white;
+    border: none;
+    padding: 0.75rem 1.5rem;
+    border-radius: 6px;
+    font-weight: 600;
+    cursor: pointer;
+    margin: 0.5rem;
+    min-height: 44px;
+    min-width: 44px;
+    transition: all 0.2s ease;
+}
+
+.extend-session-btn:hover,
+.dismiss-btn:hover {
+    background-color: var(--primary-hover);
+    transform: translateY(-1px);
+}
+
+.extend-session-btn:focus,
+.dismiss-btn:focus {
+    outline: 3px solid var(--focus-ring-light);
+    outline-offset: 2px;
+}
+
+.dismiss-btn {
+    background-color: var(--secondary-text);
+}
+
+.dismiss-btn:hover {
+    background-color: var(--text-color);
+}
+
+/* Accessible Error Dialog */
+.accessible-error-dialog {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 10000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+}
+
+.error-backdrop {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.8);
+}
+
+.error-dialog-content {
+    position: relative;
+    background-color: var(--card-background);
+    color: var(--text-color);
+    border-radius: 8px;
+    padding: 2rem;
+    max-width: 500px;
+    width: 100%;
+    text-align: center;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+    border: 2px solid var(--danger-color);
+}
+
+.error-dialog-content h2 {
+    color: var(--danger-color);
+    margin-bottom: 1rem;
+    font-size: 1.25rem;
+}
+
+.error-dialog-content p {
+    margin-bottom: 1.5rem;
+    line-height: 1.5;
+}
+
+.error-actions {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+.primary-action,
+.secondary-action {
+    background-color: var(--primary-color);
+    color: white;
+    border: none;
+    padding: 0.75rem 1.5rem;
+    border-radius: 6px;
+    font-weight: 600;
+    cursor: pointer;
+    min-height: 44px;
+    min-width: 44px;
+    transition: all 0.2s ease;
+}
+
+.primary-action:hover,
+.secondary-action:hover {
+    background-color: var(--primary-hover);
+    transform: translateY(-1px);
+}
+
+.primary-action:focus,
+.secondary-action:focus {
+    outline: 3px solid var(--focus-ring-light);
+    outline-offset: 2px;
+}
+
+.secondary-action {
+    background-color: var(--secondary-text);
+}
+
+.secondary-action:hover {
+    background-color: var(--text-color);
+}
+
+/* Language Switcher (hidden by default) */
+#language-switcher {
+    position: fixed;
+    top: 1rem;
+    right: 1rem;
+    background-color: var(--card-background);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 0.5rem;
+    box-shadow: var(--card-shadow);
+}
+
+#language-switcher label {
+    display: block;
+    font-size: 0.875rem;
+    margin-bottom: 0.25rem;
+    color: var(--text-color);
+}
+
+#lang-select {
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    padding: 0.25rem 0.5rem;
+    background-color: var(--card-background);
+    color: var(--text-color);
+    font-size: 0.875rem;
+    min-height: 44px;
+}
+
+#lang-select:focus {
+    outline: 3px solid var(--focus-ring-light);
+    outline-offset: 2px;
+}
+
+/* Enhanced Mobile Accessibility */
+@media (max-width: 768px) {
+    .timeout-content,
+    .error-dialog-content {
+        margin: 1rem;
+        padding: 1.5rem;
+    }
+    
+    .error-actions {
+        flex-direction: column;
+    }
+    
+    .primary-action,
+    .secondary-action,
+    .extend-session-btn,
+    .dismiss-btn {
+        width: 100%;
+        margin: 0.25rem 0;
+    }
+}
+
+/* High Contrast Mode Support for EN 301 549 */
+@media (prefers-contrast: high) {
+    .session-timeout-warning,
+    .accessible-error-dialog {
+        background-color: rgba(0, 0, 0, 0.95);
+    }
+    
+    .timeout-content,
+    .error-dialog-content {
+        border-width: 3px;
+        box-shadow: 0 0 0 2px var(--text-color);
+    }
+    
+    .extend-session-btn,
+    .dismiss-btn,
+    .primary-action,
+    .secondary-action {
+        border: 2px solid var(--text-color);
+    }
+    
+    #lang-select {
+        border-width: 2px;
+    }
+}
+
+/* Reduced Motion Support for EN 301 549 */
+@media (prefers-reduced-motion: reduce) {
+    .timeout-content,
+    .error-dialog-content,
+    .extend-session-btn,
+    .dismiss-btn,
+    .primary-action,
+    .secondary-action {
+        transition: none !important;
+        transform: none !important;
+    }
+    
+    .extend-session-btn:hover,
+    .dismiss-btn:hover,
+    .primary-action:hover,
+    .secondary-action:hover {
+        transform: none !important;
+    }
+}
+
+
+/* ── 3b. Dynamic components (genre nav, grids, carousel, search results) ──── */
+/* Dynamic Components CSS - Extracted from app.js */
+
+/* Genre Navigation Styles */
+.genre-navigation {
+    margin: 20px 0;
+    padding: 1.5rem;
+    background: #12121200;
+    border-radius: 16px;
+    box-shadow: none;
+    border: 0px solid var(--border-color);
+    transition: all 0.3s ease;
+}
+
+.genre-title {
+    font-size: 1.25rem;
+    margin-bottom: 1.25rem;
+    color: var(--header-color);
+    font-weight: 600;
+    position: relative;
+    padding-bottom: 0.75rem;
+}
+
+.genre-title::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 50px;
+    height: 3px;
+    background: var(--primary-color);
+    border-radius: 3px;
+}
+
+.genre-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+}
+
+.genre-pill {
+    display: flex;
+    align-items: center;
+    padding: 12px 20px;
+    border-radius: 24px;
+    background: rgba(var(--primary-rgb), 0.1);
+    color: var(--primary-color);
+    font-size: 0.95rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.25s ease;
+    white-space: nowrap;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+    position: relative;
+    overflow: hidden;
+    border: 1px solid rgba(var(--primary-rgb), 0.15);
+    letter-spacing: 0.01em;
+}
+
+.genre-pill:hover {
+    background: rgba(var(--primary-rgb), 0.18);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+    border-color: rgba(var(--primary-rgb), 0.25);
+}
+
+.genre-pill:active {
+    transform: translateY(-1px);
+}
+
+.genre-count {
+    margin-left: 10px;
+    background: rgba(var(--primary-rgb), 0.2);
+    border-radius: 16px;
+    padding: 4px 12px;
+    font-size: 0.8rem;
+    font-weight: 700;
+    line-height: 1;
+}
+
+.genre-pill.selected {
+    background: var(--primary-color);
+    color: white;
+    box-shadow: 0 4px 12px rgba(var(--primary-rgb), 0.35);
+    border-color: var(--primary-color);
+    transform: translateY(-1px);
+}
+
+.genre-pill.selected .genre-count {
+    background: rgba(255, 255, 255, 0.25);
+    color: white;
+}
+
+/* Genre View Styles */
+.genre-view {
+    padding: 1.5rem;
+}
+
+.genre-view-header {
+    display: flex;
+    align-items: center;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.genre-view-title {
+    font-size: 1.5rem;
+    color: white;
+    margin: 0;
+    text-shadow: 1px 1px 2px rgba(0,0,0,0.5);
+}
+
+.genre-count-large {
+    margin-left: auto;
+    background: rgba(255,255,255,0.2);
+    color: white;
+    padding: 5px 12px;
+    border-radius: 999px;
+    font-size: 0.9rem;
+}
+
+.back-button {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    background: rgba(0,0,0,0.4);
+    border-radius: 999px;
+    color: white;
+    border: 1px solid rgba(255,255,255,0.2);
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.back-button:hover {
+    background: rgba(0,0,0,0.6);
+    box-shadow: 0 3px 8px rgba(0,0,0,0.3);
+}
+
+.back-icon::before {
+    content: "←";
+    margin-right: 4px;
+}
+
+.audiobooks-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 20px;
+}
+
+.book-card {
+    background: var(--card-background);
+    border-radius: 12px;
+    overflow: hidden;
+    cursor: pointer;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    box-shadow: var(--card-shadow);
+    border: 1px solid var(--border-color);
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.book-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 12px 20px rgba(0,0,0,0.15);
+}
+
+.book-card-cover {
+    height: 160px;
+    background-size: cover;
+    background-position: center;
+    position: relative;
+}
+
+.card-badge {
+    position: absolute;
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: white;
+}
+
+.audio-badge {
+    top: 10px;
+    left: 10px;
+    background: var(--accent-color);
+}
+
+.duration-badge {
+    bottom: 10px;
+    right: 10px;
+    background: rgba(0,0,0,0.7);
+}
+
+.book-card-details {
+    padding: 15px;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+.book-card-title {
+    margin: 0 0 8px 0;
+    font-size: 0.95rem;
+    color: var(--text-color);
+    line-height: 1.3;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.book-card-author {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--secondary-text);
+    font-weight: 500;
+}
+
+/* Genre Grid Styles */
+.genre-books-grid-card {
+    background: var(--card-background);
+    border-radius: 0px;
+    padding: 1.5rem;
+    margin-bottom: 1.2rem;
+    box-shadow: none;
+    border: 0px solid var(--border-color);
+    transition: all 0.3s ease;
+}
+
+.genre-grid-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.5rem;
+}
+
+.genre-grid-title-area {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.genre-grid-title {
+    font-size: 1.5rem;
+    margin: 0;
+    color: var(--header-color);
+}
+
+.genre-count-badge {
+    background: rgba(var(--primary-rgb), 0.1);
+    color: var(--primary-color);
+    padding: 5px 12px;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 500;
+}
+
+/* Horizontal scrolling container */
+.books-grid-container {
+    position: relative;
+    display: flex;
+    align-items: center;
+    width: 100%;
+}
+
+.books-grid {
+    display: flex;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scroll-behavior: smooth;
+    -webkit-overflow-scrolling: touch;
+    padding: 10px 0;
+    gap: 16px;
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* IE and Edge */
+}
+
+/* Hide scrollbar for Chrome, Safari and Opera */
+.books-grid::-webkit-scrollbar {
+    display: none;
+}
+
+/* Scroll buttons */
+.scroll-button {
+    position: absolute;
+    z-index: 10;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: var(--card-background);
+    color: var(--primary-color);
+    border: 1px solid rgba(var(--primary-rgb), 0.3);
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    opacity: 0.9;
+}
+
+.scroll-button:hover {
+    background: rgba(var(--primary-rgb), 0.1);
+    transform: scale(1.1);
+    opacity: 1;
+}
+
+.scroll-button.hidden {
+    opacity: 0;
+    visibility: hidden;
+    transform: scale(0.8);
+}
+
+.scroll-left {
+    left: -10px;
+}
+
+.scroll-right {
+    right: -10px;
+}
+
+.arrow-left-icon, .arrow-right-icon {
+    font-size: 1.2rem;
+    font-weight: 700;
+}
+
+.book-grid-item {
+    flex: 0 0 180px;
+    background: rgba(var(--card-background-rgb), 0.5);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    overflow: hidden;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.book-grid-item:hover {
+    transform: translateY(-8px);
+    box-shadow: 0 12px 20px rgba(0,0,0,0.1);
+}
+
+.book-grid-cover {
+    height: 120px;
+    background-size: cover;
+    background-position: center;
+    position: relative;
+}
+
+.book-grid-duration {
+    position: absolute;
+    bottom: 8px;
+    right: 8px;
+    background: rgba(0,0,0,0.75);
+    color: white;
+    padding: 3px 8px;
+    border-radius: 4px;
+    font-size: 0.75rem;
+}
+
+.book-grid-details {
+    padding: 12px;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+.book-grid-title {
+    margin: 0 0 6px 0;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--text-color);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    line-height: 1.3;
+}
+
+.book-grid-author {
+    margin: 0;
+    font-size: 0.8rem;
+    color: var(--secondary-text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* Search Results Styles */
+.search-results-card {
+    margin: 20px 0;
+    padding: 1.5rem;
+    background: var(--card-background);
+    border-radius: 16px;
+    box-shadow: var(--card-shadow);
+    border: 1px solid var(--border-color);
+    transition: all 0.3s ease;
+    margin-bottom: 30px;
+}
+
+.search-results-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.search-info {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.search-title {
+    font-size: 1.5rem;
+    color: var(--header-color);
+    margin: 0;
+    font-weight: 600;
+}
+
+.results-count {
+    color: var(--secondary-text);
+    font-size: 0.9rem;
+}
+
+.pagination-controls {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+    margin-top: 1.5rem;
+}
+
+.pagination-button {
+    padding: 8px 16px;
+    background: rgba(var(--primary-rgb), 0.1);
+    border: 1px solid rgba(var(--primary-rgb), 0.2);
+    border-radius: 999px;
+    color: var(--primary-color);
+    cursor: pointer;
+    transition: all 0.2s ease;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.pagination-button:hover:not([disabled]) {
+    background: rgba(var(--primary-rgb), 0.2);
+    box-shadow: 0 3px 8px rgba(0,0,0,0.1);
+}
+
+.pagination-button[disabled] {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.page-indicator {
+    color: var(--secondary-text);
+    font-size: 0.9rem;
+}
+
+.prev-icon::before {
+    content: "←";
+}
+
+.next-icon::before {
+    content: "→";
+}
+
+.no-results {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 3rem;
+    text-align: center;
+}
+
+.no-results h3 {
+    margin: 1rem 0 0.5rem;
+    color: var(--header-color);
+}
+
+.no-results p {
+    color: var(--secondary-text);
+    margin-bottom: 1.5rem;
+}
+
+.search-icon {
+    display: inline-block;
+    width: 60px;
+    height: 60px;
+    background-color: rgba(var(--primary-rgb), 0.1);
+    border-radius: 50%;
+    position: relative;
+}
+
+.search-icon::before {
+    content: "🔍";
+    font-size: 2rem;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}
+
+/* Animation classes */
+.fade-in {
+    animation: fadeIn 0.4s ease forwards;
+}
+
+.fade-out {
+    animation: fadeOut 0.3s ease forwards;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes fadeOut {
+    from { opacity: 1; transform: translateY(0); }
+    to { opacity: 0; transform: translateY(10px); }
+}
+
+/* Mobile Responsive Styles */
+@media (min-width: 1024px) {
+    .genre-list {
+        gap: 14px;
+    }
+    
+    .genre-pill {
+        padding: 13px 22px;
+        font-size: 1rem;
+    }
+    
+    .genre-count {
+        padding: 4px 13px;
+        font-size: 0.85rem;
+    }
+}
+
+@media (max-width: 768px) {
+    .genre-navigation {
+        padding: 1.25rem;
+    }
+    
+    .genre-pill {
+        padding: 8px 14px;
+        font-size: 0.85rem;
+    }
+    
+    .audiobooks-grid {
+        grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+        gap: 15px;
+    }
+    
+    .genre-view {
+        padding: 1rem;
+    }
+    
+    .genre-view-header {
+        margin-bottom: 1rem;
+    }
+    
+    .genre-view-title {
+        font-size: 1.25rem;
+    }
+    
+    .genre-books-grid-card {
+        padding: 1rem;
+        margin: 1rem 0;
+    }
+    
+    .genre-grid-title {
+        font-size: 1.25rem;
+    }
+    
+    .book-grid-item {
+        flex: 0 0 140px;
+    }
+    
+    .book-grid-cover {
+        height: 100px;
+    }
+    
+    .scroll-button {
+        width: 36px;
+        height: 36px;
+    }
+    
+    .arrow-left-icon, .arrow-right-icon {
+        font-size: 1rem;
+    }
+    
+    .search-results-card {
+        padding: 1rem;
+    }
+    
+    .search-title {
+        font-size: 1.25rem;
+    }
+    
+    .pagination-button {
+        padding: 6px 12px;
+        font-size: 0.85rem;
+    }
+}
+
+
+/* ── 4. Mobile overrides (genre nav / categories) ──────────────────────────── */
+/* Mobile Categories Navigation Styles */
+.mobile-categories-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    padding: 10px 0;
+    margin-bottom: 15px;
+    position: relative;
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* IE and Edge */
+    scroll-behavior: smooth; /* Smooth scrolling for better UX */
+    /* Add physics-based scrolling for iOS */
+    -webkit-overflow-scrolling: touch;
+    /* Prevent text selection during swipe */
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    user-select: none;
+}
+
+@media (max-width: 480px) {
+    .mobile-categories-container {
+        padding: 8px 0;
+        margin-bottom: 12px;
+    }
+}
+
+.mobile-categories-container::-webkit-scrollbar {
+    display: none; /* Chrome, Safari, Opera */
+}
+
+/* Style the mobile genre navigation */
+@media (max-width: 768px) {
+    .genre-navigation {
+        padding: 0.5rem !important;
+        margin: 10px 0 !important;
+        width: 100%;
+        overflow-x: auto;
+        position: sticky;
+        top: 0;
+        z-index: 10;
+        background-color: var(--background-color);
+        margin-top: 0 !important;
+        padding-top: 10px !important;
+        padding-bottom: 10px !important;
+    }
+
+    .genre-list {
+        display: flex !important;
+        flex-wrap: nowrap !important;
+        gap: 8px !important;
+        padding-bottom: 5px;
+        width: auto;
+        min-width: max-content;
+        /* Add snap scrolling for better mobile experience */
+        scroll-snap-type: x mandatory;
+        /* Add extra padding for better thumb scrolling experience */
+        padding-left: 4px;
+        padding-right: 4px;
+    }
+    
+    @media (max-width: 480px) {
+        .genre-list {
+            gap: 5px !important; /* Reduced from 6px for more compact layout */
+            padding-bottom: 3px;
+            justify-content: flex-start !important; /* Ensure proper alignment */
+        }
+    }
+
+    .genre-pill {
+        flex-shrink: 0;
+        padding: 6px 10px !important;
+        font-size: 0.75rem !important;
+        border: none !important;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1) !important;
+        white-space: nowrap;
+        transition: transform 0.2s ease, background-color 0.2s ease !important;
+        -webkit-tap-highlight-color: transparent; /* Remove default mobile tap highlight */
+        /* Improve touch target size */
+        min-height: 36px;
+        display: flex !important;
+        align-items: center !important;
+        justify-content: center !important;
+        /* Add snap scrolling */
+        scroll-snap-align: start;
+        /* Limit maximum width on small screens */
+        max-width: 140px !important;
+        overflow: hidden !important;
+        text-overflow: ellipsis !important;
+    }
+    
+    /* Special sizing for mobile portrait */
+    @media (max-width: 480px) {
+        .genre-pill {
+            max-width: 100px !important; /* Reduced from 110px to have more pills in view */
+            padding: 6px 8px !important;
+            font-size: 0.7rem !important;
+            /* Fix shadow rendering on mobile */
+            box-shadow: 0 1px 3px rgba(0,0,0,0.08) !important;
+            width: auto !important; /* Allow buttons to size based on content */
+            flex-basis: auto !important; /* Auto flex basis */
+        }
+    }
+    
+    /* Add touch feedback animation */
+    .genre-pill:active {
+        transform: scale(0.95) !important;
+    }
+
+    .genre-count {
+        padding: 2px 6px !important;
+        font-size: 0.7rem !important;
+    }
+    
+    @media (max-width: 480px) {
+        .genre-count {
+            padding: 1px 4px !important;
+            font-size: 0.65rem !important;
+            margin-left: 3px !important;
+            /* Match the reduced shadow effect */
+            box-shadow: none !important;
+        }
+    }
+    
+    /* Make mobile scrolling indicator */
+    .mobile-categories-container::after {
+        content: '';
+        position: absolute;
+        right: 0;
+        top: 0;
+        height: 100%;
+        width: 30px;
+        background: linear-gradient(to right, transparent, rgba(var(--card-background-rgb), 0.95));
+        pointer-events: none;
+        opacity: 0.8;
+    }
+    
+    @media (max-width: 480px) {
+        .mobile-categories-container::after {
+            width: 20px;
+        }
+    }
+    
+    /* Add left gradient for scroll indication when not at start */
+    .mobile-categories-container.scrolled-right::before {
+        content: '';
+        position: absolute;
+        left: 0;
+        top: 0;
+        height: 100%;
+        width: 30px;
+        background: linear-gradient(to left, transparent, rgba(var(--card-background-rgb), 0.95));
+        pointer-events: none;
+        opacity: 0.8;
+    }
+    
+    @media (max-width: 480px) {
+        .mobile-categories-container.scrolled-right::before {
+            width: 20px;
+        }
+    }
+}
+
+/* Active state for category selection */
+.genre-pill.active {
+    background: var(--primary-color) !important;
+    color: white !important;
+}
+
+/* Enhanced Mobile Navigation Controls */
+.mobile-nav-control {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    background: var(--primary-color);
+    color: white;
+    border: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    z-index: 20;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease, transform 0.2s ease;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+}
+
+.mobile-nav-control span {
+    font-size: 18px;
+    line-height: 1;
+}
+
+.left-nav {
+    left: 5px;
+}
+
+.right-nav {
+    right: 5px;
+}
+
+.mobile-nav-control.visible {
+    opacity: 0.8;
+    pointer-events: auto;
+}
+
+.mobile-nav-control:hover {
+    opacity: 1;
+    transform: translateY(-50%) scale(1.1);
+}
+
+.mobile-nav-control:active {
+    transform: translateY(-50%) scale(0.95);
+}
+
+/* Hide gradients when no scrolling needed */
+.mobile-categories-container.no-scroll-needed::after,
+.mobile-categories-container.no-scroll-needed::before {
+    display: none;
+}
+
+/* Touch feedback styles */
+.mobile-categories-container.touching {
+    cursor: grabbing;
+}
+
+/* Hide navigation controls on smaller screens where they cause issues */
+@media (max-width: 480px) {
+    .mobile-nav-control {
+        display: none;
+    }
+}
+
+
+/* ── 4b. Mobile fixes (small-screen pill / grid tuning) ────────────────────── */
+/* Additional CSS fixes for mobile genre navigation buttons */
+@media (max-width: 480px) {
+    /* Fix for the genre pill width issue in portrait mode - optimized for space */
+    .genre-pill {
+        max-width: 100px !important; /* Reduced from 110px to have more pills in view */
+        padding: 5px 7px !important; /* Slightly more compact */
+        font-size: 0.7rem !important;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.08) !important; /* Lighter shadow for mobile */
+        width: auto !important; /* Allow buttons to size based on content */
+        flex-basis: auto !important; /* Auto flex basis */
+        overflow: hidden !important;
+        border-radius: 8px !important; /* Further reduced border radius for modern look */
+        touch-action: manipulation !important; /* Improve touch response */
+        -webkit-tap-highlight-color: transparent !important; /* Remove tap highlight on iOS */
+    }
+    
+    /* Ensure genre name doesn't overflow - improved text handling */
+    .genre-name {
+        overflow: hidden !important;
+        text-overflow: ellipsis !important;
+        max-width: 70px !important; /* Slightly increased for better readability */
+        white-space: nowrap !important;
+    }
+    
+    /* Fix for the genre count badge */
+    .genre-count {
+        padding: 1px 4px !important;
+        font-size: 0.65rem !important;
+        margin-left: 3px !important;
+        box-shadow: none !important; /* Remove shadow from the count badge */
+        min-width: 18px !important;
+        text-align: center !important;
+        border-radius: 8px !important;
+        display: flex !important;
+        align-items: center !important;
+        justify-content: center !important;
+    }
+    
+    /* Adjust spacing for better arrangement */
+    .genre-list {
+        gap: 5px !important; /* Reduced from 6px for more compact layout */
+        justify-content: flex-start !important; /* Ensure proper alignment */
+        padding-bottom: 3px !important;
+        overscroll-behavior-x: contain !important; /* Prevent page overscroll */
+        scroll-padding: 0.5rem !important; /* Better scroll experience */
+    }
+    
+    /* Fix for multiple genre pills in a row */
+    .mobile-categories-container {
+        padding: 8px 4px !important;
+    }
+    
+    /* Fix for the active state of genre pills */
+    .genre-pill.active, .genre-pill.selected {
+        box-shadow: 0 2px 5px rgba(var(--primary-rgb), 0.2) !important;
+    }
+    
+    /* Improve touch feedback */
+    .genre-pill:active {
+        transform: scale(0.95) !important;
+        box-shadow: 0 1px 2px rgba(0,0,0,0.1) !important;
+    }
+}
+
+/* Additional fixes for very small screens (iPhone SE, etc.) */
+@media (max-width: 375px) {
+    .genre-pill {
+        max-width: 85px !important; /* Reduced from 90px for better screen usage */
+        padding: 4px 5px !important; /* More compact padding */
+        margin: 0 !important; /* Remove any margin */
+    }
+    
+    .genre-name {
+        max-width: 58px !important; /* Slightly increased */
+        font-size: 0.65rem !important; /* Slightly smaller text */
+    }
+    
+    .genre-count {
+        min-width: 14px !important; /* Smaller count badge */
+        font-size: 0.55rem !important; /* Smaller font for badge */
+        padding: 1px 3px !important; /* Tighter padding */
+    }
+    
+    .genre-list {
+        gap: 3px !important; /* Further reduced gap */
+        padding: 0 2px !important; /* Minimal padding */
+    }
+}
+
+/* Fix for portrait mode container */
+.mobile-categories-container.portrait-mode {
+    padding: 6px 3px !important;
+}
+
+/* Fix the mobile navigation shadow rendering */
+.mobile-nav-control {
+    box-shadow: 0 2px 6px rgba(0,0,0,0.15) !important;
+}
+
+/* Ottimizzazioni per lo schermo intero sui dispositivi mobili */
+@media (max-width: 768px) {
+    /* Ottimizzazione della griglia di contenuti per occupare tutto lo spazio disponibile */
+    .audiobook-grid {
+        grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)) !important;
+        gap: 10px !important;
+        padding: 0 8px !important;
+        width: 100% !important;
+        max-width: 100vw !important;
+    }
+    
+    /* Card dei contenuti ottimizzate per la visualizzazione mobile */
+    .audiobook-card {
+        width: 100% !important;
+        min-height: 220px !important;
+        margin: 0 !important;
+    }
+    
+    /* Immagine di copertina ridimensionata per adattarsi meglio */
+    .audiobook-cover {
+        height: 140px !important;
+        object-fit: cover !important;
+    }
+    
+    /* Ridurre lo spazio occupato dall'intestazione */
+    .site-header {
+        padding: 8px 12px !important;
+    }
+    
+    /* Migliorare l'esperienza di ricerca su mobile */
+    .search-container {
+        width: 100% !important;
+        max-width: 100% !important;
+        margin: 8px 0 !important;
+    }
+    
+    .search-input {
+        height: 40px !important;
+        font-size: 0.9rem !important;
+    }
+}
+
+
+/* ── 5. iOS safe-area & touch helpers ──────────────────────────────────────── */
+/* File: tailwind-modern-ios.css */
+/* Ottimizzazioni moderne per iOS con Tailwind */
+
+/* Gestione dinamica del notch e altre aree di sicurezza su iOS */
+.ios-safe-inset {
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
+}
+
+/* Stili specifici per il notch superiore */
+.ios-top-safe {
+  padding-top: env(safe-area-inset-top);
+}
+
+/* Stili specifici per la home indicator */
+.ios-bottom-safe {
+  padding-bottom: env(safe-area-inset-bottom);
+}
+
+/* Navigazione scorrevole migliorata per iOS */
+.ios-scroll {
+  -webkit-overflow-scrolling: touch;
+  scroll-behavior: smooth;
+  overscroll-behavior-x: contain;
+  scroll-snap-type: x mandatory;
+}
+
+/* Ottimizzazione dello scorrimento orizzontale */
+.ios-scroll-x {
+  -webkit-overflow-scrolling: touch;
+  scroll-behavior: smooth;
+  overscroll-behavior-x: contain;
+  scroll-snap-type: x mandatory;
+  display: flex;
+  overflow-x: auto;
+  overflow-y: hidden;
+  width: 100%;
+  max-width: 100vw;
+  scrollbar-width: none;
+}
+
+.ios-scroll-x::-webkit-scrollbar {
+  display: none;
+}
+
+/* Ottimizzazione dell'area di interazione tattile su iOS */
+.ios-touch-target {
+  min-height: 44px;
+  min-width: 44px;
+  padding: 8px;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* Animazioni ottimizzate per WebKit */
+.ios-smooth-animation {
+  -webkit-transform: translateZ(0);
+  -webkit-backface-visibility: hidden;
+  transform: translateZ(0);
+  backface-visibility: hidden;
+  transition: transform 0.2s cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+/* Stile avanzato dei pulsanti su iOS */
+.ios-button {
+  border-radius: 10px;
+  padding: 10px 16px;
+  font-weight: 500;
+  background-color: var(--primary-color, #4a6cf7);
+  color: white;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+  transition: transform 0.1s ease, background-color 0.15s ease;
+}
+
+.ios-button:active {
+  transform: scale(0.97);
+  background-color: var(--primary-hover, #3a56d4);
+}
+
+/* Contenitori moderni per iOS */
+.ios-card {
+  border-radius: 12px;
+  overflow: hidden;
+  background-color: var(--card-background, #ffffff);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  margin-bottom: 16px;
+}
+
+/* Supporto per la modalità dark */
+@media (prefers-color-scheme: dark) {
+  .ios-card {
+    background-color: var(--dark-card, #121212);
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.18);
+  }
+}
+
+/* Adattamenti per schermo iOS Portrait */
+@media screen and (orientation: portrait) and (-webkit-min-device-pixel-ratio: 2) {
+  .ios-portrait-adjust {
+    width: calc(100% - env(safe-area-inset-left) - env(safe-area-inset-right));
+    margin-left: env(safe-area-inset-left);
+    margin-right: env(safe-area-inset-right);
+  }
+}

--- a/app.js
+++ b/app.js
@@ -293,12 +293,27 @@ document.addEventListener('DOMContentLoaded', () => {
     
     // Function to fetch fresh data from server
     function fetchFreshData(isBackgroundUpdate) {
+        // Try augmented.json first, then fall back to audiobooks.json (parity with production)
         fetch('augmented.json')
             .then(response => {
                 if (!response.ok) {
                     throw new Error(`HTTP error! status: ${response.status}`);
                 }
                 return response.json();
+            })
+            .catch(error => {
+                console.warn('augmented.json failed, trying audiobooks.json fallback:', error.message || error);
+                return fetch('audiobooks.json')
+                    .then(response => {
+                        if (!response.ok) {
+                            throw new Error(`Fallback failed - audiobooks.json HTTP status: ${response.status}`);
+                        }
+                        return response.json();
+                    })
+                    .catch(fallbackError => {
+                        console.error('Both augmented.json and audiobooks.json failed to load');
+                        throw new Error(`Failed to load audiobooks data: ${fallbackError.message || fallbackError}`);
+                    });
             })
             .then(data => {
                 // Save to cache for next time
@@ -1509,237 +1524,6 @@ document.addEventListener('DOMContentLoaded', () => {
         return (match && match[2].length === 11) ? match[2] : null;
     }
     
-    
-    // Cleanup on page unload to prevent memory leaks
-    window.addEventListener('beforeunload', () => {
-        if (updateInterval) {
-            clearInterval(updateInterval);
-        }
-        if (youtubePlayer && youtubePlayer.destroy) {
-            youtubePlayer.destroy();
-        }
-    });
-        
-        // Check if user preference for collapsing is stored
-        const isCollapsed = localStorage.getItem('changelogCollapsed') === 'true';
-        if (isCollapsed) {
-            changelogCard.classList.add('collapsed');
-            changelogToggle.querySelector('.collapse-icon').textContent = '+';
-            changelogToggle.setAttribute('aria-expanded', 'false');
-        } else {
-            changelogToggle.setAttribute('aria-expanded', 'true');
-        }
-        
-        // Toggle changelog visibility with enhanced accessibility
-        changelogToggle.addEventListener('click', () => {
-            toggleChangelog();
-        });
-        
-        // WCAG: Add keyboard support for changelog toggle
-        changelogToggle.addEventListener('keydown', (e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                toggleChangelog();
-            }
-        });
-        
-        function toggleChangelog() {
-            const wasCollapsed = changelogCard.classList.contains('collapsed');
-            changelogCard.classList.toggle('collapsed');
-            const isNowCollapsed = changelogCard.classList.contains('collapsed');
-            
-            // Update localStorage
-            localStorage.setItem('changelogCollapsed', isNowCollapsed);
-            
-            // Update visual indicator
-            changelogToggle.querySelector('.collapse-icon').textContent = isNowCollapsed ? '+' : '−';
-            
-            // Update ARIA attributes
-            changelogToggle.setAttribute('aria-expanded', !isNowCollapsed);
-            
-            // Announce to screen readers
-            announceToScreenReader(
-                isNowCollapsed ? 'Aggiornamenti nascosti' : 'Aggiornamenti mostrati'
-            );
-        }
-        
-        // Load changelog data with accessibility
-        document.getElementById('changelog-content').innerHTML = `
-            <div class="loading-spinner small" aria-hidden="true"></div>
-            <p>Caricamento aggiornamenti...</p>
-        `;
-        
-        // Try loading the changelog data
-        fetchChangelog();
-    }
-
-    function fetchChangelog() {
-        // Set a timeout for the fetch
-        const timeoutPromise = new Promise((_, reject) => 
-            setTimeout(() => reject(new Error('Timeout')), 8000)
-        );
-        
-        // Fetch with timeout handling
-        Promise.race([
-            fetch(config.changelogPath),
-            timeoutPromise
-        ])
-        .then(response => {
-            if (!response.ok) {
-                throw new Error(`Network response was not ok: ${response.status}`);
-            }
-            return response.json();
-        })
-        .then(data => {
-            if (!data || !data.entries || !Array.isArray(data.entries)) {
-                throw new Error('Invalid data format');
-            }
-            displayChangelog(data);
-        })
-        .catch(error => {
-            console.error('Error loading changelog:', error);
-            document.getElementById('changelog-content').innerHTML = `
-                <div class="error-message small">
-                    <p>Impossibile caricare gli aggiornamenti: ${error.message || 'Unknown error'}</p>
-                    <button id="retry-changelog" class="control-button small">Riprova</button>
-                </div>
-            `;
-            
-            // Add retry button functionality
-            document.getElementById('retry-changelog')?.addEventListener('click', () => {
-                document.getElementById('changelog-content').innerHTML = `
-                    <div class="loading-spinner small"></div>
-                    <p>Caricamento aggiornamenti...</p>
-                `;
-                fetchChangelog();
-            });
-        });
-    }
-
-    function displayChangelog(data) {
-        const changelogContent = document.getElementById('changelog-content');
-        const entries = data.entries.slice(0, config.maxChangelogEntries); // Limit number of entries
-        
-        if (!entries || entries.length === 0) {
-            changelogContent.innerHTML = '<p>Nessun aggiornamento disponibile.</p>';
-            return;
-        }
-        
-        let html = '';
-        entries.forEach(entry => {
-            const date = new Date(entry.date);
-            const formattedDate = date.toLocaleDateString('it-IT', { 
-                year: 'numeric', 
-                month: 'long', 
-                day: 'numeric' 
-            });
-            
-            html += `
-                <div class="changelog-entry">
-                    <div class="changelog-date">${formattedDate}</div>
-                    <h3 class="changelog-title">${entry.title}</h3>
-                    <p class="changelog-description">${entry.description || ''}</p>
-                    ${renderChangelogItems(entry.changes)}
-                </div>
-            `;
-        });
-        
-        changelogContent.innerHTML = html;
-    }
-    
-    // Add the missing renderChangelogItems function
-    function renderChangelogItems(changes) {
-        if (!changes || !Array.isArray(changes) || changes.length === 0) {
-            return '';
-        }
-        
-        // Add a style tag for the changelog items
-        const styleTag = `
-        <style>
-            .changelog-items {
-                padding-left: 0;
-                list-style-type: none;
-                margin-top: 10px;
-            }
-            .changelog-items li {
-                margin-bottom: 6px;
-                display: flex;
-                align-items: flex-start;
-            }
-            .change-icon {
-                display: inline-block;
-                width: 22px;
-                text-align: center;
-                margin-right: 10px;
-            }
-            .change-content {
-                font-size: 0.9em;
-                line-height: 1.4;
-                flex: 1;
-                padding-top: 2px;
-            }
-            .change-type-feature .change-content {
-                color: var(--accent-color, #10b981);
-            }
-            .change-type-fix .change-content {
-                color: var(--fix-color, #f59e0b);
-            }
-        </style>`;
-        
-        let html = styleTag + '<ul class="changelog-items">';
-        changes.forEach(item => {
-            // Check if item is a string or has a type property
-            if (typeof item === 'string') {
-                html += `
-                    <li>
-                        <span class="change-icon">•</span>
-                        <span class="change-content">${item}</span>
-                    </li>
-                `;
-            } else if (item && typeof item === 'object') {
-                const type = item.type || 'other';
-                const content = item.text || item.content || '';
-                html += `
-                    <li class="change-type-${type.toLowerCase()}">
-                        ${getChangeTypeIcon(type)}
-                        <span class="change-content">${content}</span>
-                    </li>
-                `;
-            }
-        });
-        html += '</ul>';
-        
-        return html;
-    }
-
-    // Helper function to get appropriate icon for change types
-    function getChangeTypeIcon(type) {
-        const lowerType = type.toLowerCase();
-        switch (lowerType) {
-            case 'feature':
-            case 'new':
-                return '<span class="change-icon">✨</span>';
-            case 'fix':
-            case 'bugfix':
-                return '<span class="change-icon">🐛</span>';
-            case 'improvement':
-            case 'enhance':
-                return '<span class="change-icon">⚡️</span>';
-            case 'security':
-                return '<span class="change-icon">🔒</span>';
-            case 'deprecate':
-            case 'deprecated':
-                return '<span class="change-icon">⚠️</span>';
-            case 'remove':
-            case 'removed':
-                return '<span class="change-icon">🗑️</span>';
-            case 'docs':
-            case 'documentation':
-                return '<span class="change-icon">📝</span>';
-            default:
-                return '<span class="change-icon">•</span>';
-        }
-    }
     
     // Cleanup on page unload to prevent memory leaks
     window.addEventListener('beforeunload', () => {

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# deploy.sh — resilient static-site deploy for audiolibri.org
+#
+# The nginx docroot (/var/www/audiolibri.org) is a plain git checkout, so a
+# deploy is just "pull the latest commit". This script does it *safely*:
+#
+#   - single-instance lock        (no overlapping runs)
+#   - fast-forward only            (never rewrites history on the server)
+#   - refuses to clobber local edits unless you ask (FORCE_RESET=1)
+#   - validates app.js + JSON before declaring success
+#   - automatic rollback to the previous commit if validation fails
+#   - runs git as the docroot owner (www-data) to keep permissions correct
+#
+# Run on origin-01 as root (or as www-data).
+#
+#   ./deploy.sh                          # deploy origin/main
+#   BRANCH=redesign/netflix-seo ./deploy.sh
+#   FORCE_RESET=1 ./deploy.sh            # one-time: hard-reset a DIVERGED
+#                                        # checkout to origin/BRANCH
+#   RELOAD_NGINX=1 ./deploy.sh           # also reload nginx (only if config changed)
+#
+set -euo pipefail
+
+# ---- config (override via environment) --------------------------------------
+DIR="${DIR:-/var/www/audiolibri.org}"
+BRANCH="${BRANCH:-main}"
+REMOTE="${REMOTE:-origin}"
+OWNER="${OWNER:-www-data}"
+LOG="${LOG:-/var/log/audiolibri-deploy.log}"
+LOCK="${LOCK:-/run/audiolibri-deploy.lock}"
+RELOAD_NGINX="${RELOAD_NGINX:-0}"
+FORCE_RESET="${FORCE_RESET:-0}"
+# -----------------------------------------------------------------------------
+
+log()  { printf '%s  %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$*" | tee -a "$LOG" >&2; }
+die()  { log "ERROR: $*"; exit 1; }
+
+# Run git as the docroot owner so file ownership never drifts and we avoid
+# git's "dubious ownership" guard. If we're already that user, skip sudo.
+git_as() {
+    if [ "$(id -un)" = "$OWNER" ]; then
+        git -C "$DIR" "$@"
+    else
+        sudo -u "$OWNER" git -C "$DIR" "$@"
+    fi
+}
+
+# --- single instance ---------------------------------------------------------
+exec 9>"$LOCK" || die "cannot open lock file $LOCK"
+flock -n 9     || die "another deploy is already running (lock: $LOCK)"
+
+[ -d "$DIR/.git" ] || die "$DIR is not a git checkout"
+
+# trust the docroot for the owner (idempotent)
+git_as config --global --get-all safe.directory 2>/dev/null | grep -qxF "$DIR" \
+    || git_as config --global --add safe.directory "$DIR" || true
+
+OLD="$(git_as rev-parse HEAD)"
+log "current: ${OLD:0:8} on $(git_as rev-parse --abbrev-ref HEAD)"
+
+log "fetching $REMOTE ..."
+git_as fetch --prune --quiet "$REMOTE" || die "git fetch failed"
+
+TARGET="$(git_as rev-parse "$REMOTE/$BRANCH" 2>/dev/null)" || die "unknown ref $REMOTE/$BRANCH"
+
+if [ "$OLD" = "$TARGET" ]; then
+    log "already up to date ($BRANCH @ ${TARGET:0:8}) — nothing to do."
+    exit 0
+fi
+
+# --- refuse to silently discard local edits ----------------------------------
+if [ -n "$(git_as status --porcelain)" ] && [ "$FORCE_RESET" != "1" ]; then
+    die "working tree has local changes — commit them, or rerun with FORCE_RESET=1 to discard."
+fi
+
+# --- update ------------------------------------------------------------------
+if [ "$FORCE_RESET" = "1" ]; then
+    log "FORCE_RESET: hard-resetting to $REMOTE/$BRANCH (local changes discarded)"
+    git_as reset --hard "$REMOTE/$BRANCH" || die "reset failed"
+elif ! git_as merge --ff-only "$REMOTE/$BRANCH"; then
+    die "cannot fast-forward $BRANCH (history diverged). One-time reconcile: FORCE_RESET=1 ./deploy.sh"
+fi
+
+NEW="$(git_as rev-parse HEAD)"
+log "updated: ${OLD:0:8} -> ${NEW:0:8}"
+
+# --- validate, rollback on failure -------------------------------------------
+rollback() { log "VALIDATION FAILED: $*"; log "rolling back to ${OLD:0:8}"; git_as reset --hard "$OLD"; exit 1; }
+
+for f in index.html app.js; do
+    [ -s "$DIR/$f" ] || rollback "$f is missing or empty"
+done
+[ -s "$DIR/app.css" ] || [ -s "$DIR/styles.css" ] || rollback "no stylesheet found (app.css or styles.css)"
+
+# JS syntax — authoritative when node is available (install it for a real gate)
+if command -v node >/dev/null 2>&1; then
+    node --check "$DIR/app.js" 2>>"$LOG" || rollback "app.js has a JavaScript syntax error"
+    log "app.js syntax OK"
+else
+    log "WARNING: node not found — cannot syntax-check app.js (consider installing nodejs)"
+fi
+
+# JSON integrity (python3 ships with Debian/Ubuntu)
+if command -v python3 >/dev/null 2>&1; then
+    for j in augmented.json audiobooks.json; do
+        [ -f "$DIR/$j" ] && { python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$DIR/$j" 2>>"$LOG" \
+            || rollback "$j is not valid JSON"; }
+    done
+    log "JSON integrity OK"
+fi
+
+# --- finalize ----------------------------------------------------------------
+[ "$(id -u)" = "0" ] && chown -R "$OWNER":"$OWNER" "$DIR" 2>/dev/null || true
+
+if [ "$RELOAD_NGINX" = "1" ]; then
+    if nginx -t 2>>"$LOG"; then systemctl reload nginx && log "nginx reloaded"; else log "WARNING: nginx -t failed — NOT reloaded"; fi
+fi
+
+log "✅ deploy OK — $BRANCH now at ${NEW:0:8}"

--- a/deploy/audiolibri-deploy.service
+++ b/deploy/audiolibri-deploy.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Deploy audiolibri.org (resilient git pull + validate + rollback)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+# Runs as root; deploy.sh drops to www-data for git operations.
+ExecStart=/var/www/audiolibri.org/deploy.sh
+Nice=10
+# A failed deploy already rolls itself back, so don't hard-fail the unit.
+SuccessExitStatus=0 1

--- a/deploy/audiolibri-deploy.timer
+++ b/deploy/audiolibri-deploy.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Auto-deploy audiolibri.org on a schedule
+
+[Timer]
+# First run shortly after boot, then every 5 minutes.
+OnBootSec=2min
+OnUnitActiveSec=5min
+# Catch up if the machine was off when a run was due.
+Persistent=true
+# Avoid every-host-at-once stampedes (harmless here, good hygiene).
+RandomizedDelaySec=30
+
+[Install]
+WantedBy=timers.target

--- a/index.html
+++ b/index.html
@@ -85,20 +85,9 @@
     }
     </script>
     
-    <link rel="stylesheet" href="styles.css">
-    <link rel="stylesheet" href="tailwind-styles.css">
-    <link rel="stylesheet" href="mobile-navigation.css">
-    <link rel="stylesheet" href="mobile-fixes.css">
-    <link rel="stylesheet" href="dynamic-components.css">
-    <!-- Mobile optimization libraries -->
-    <link rel="stylesheet" href="tailwind-mobile.css">
-    <link rel="stylesheet" href="tailwind-grid-components.css">
-    <link rel="stylesheet" href="tailwind-nav-components.css">
-    <link rel="stylesheet" href="tailwind-modern-ios.css">
-    
-    <!-- Preload critical CSS to prevent FOUC -->
-    <link rel="preload" href="styles.css" as="style">
-    <link rel="preload" href="tailwind-styles.css" as="style">
+    <!-- Single consolidated stylesheet (replaces the former 9-file CSS stack) -->
+    <link rel="preload" href="app.css" as="style">
+    <link rel="stylesheet" href="app.css">
     
     <!-- Add before other resources -->
     <link rel="preconnect" href="https://www.youtube.com">
@@ -226,7 +215,9 @@
     <script src="mobile-enhancements.js"></script> <!-- Additional mobile UI enhancements -->
     <!-- Service Worker Registration -->
     <script>
-        if ('serviceWorker' in navigator) {
+        // Skip the service worker on local dev hosts so cache-first never serves stale assets.
+        const swIsLocalDev = ['localhost', '127.0.0.1', '0.0.0.0', ''].includes(location.hostname);
+        if ('serviceWorker' in navigator && !swIsLocalDev) {
             window.addEventListener('load', () => {
                 navigator.serviceWorker.register('/service-worker.js')
                     .then(registration => {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,15 +1,8 @@
-const CACHE_NAME = 'audiolibri-cache-v3';
+const CACHE_NAME = 'audiolibri-cache-v4';
 const ASSETS_TO_CACHE = [
   '/',
   '/index.html',
-  '/styles.css',
-  '/tailwind-styles.css',
-  '/mobile-navigation.css',
-  '/mobile-fixes.css',
-  '/tailwind-mobile.css',
-  '/tailwind-grid-components.css',
-  '/tailwind-nav-components.css',
-  '/tailwind-modern-ios.css',
+  '/app.css',
   '/app.js',
   '/mobile-navigation.js',
   '/mobile-enhancements.js',


### PR DESCRIPTION
## Perché

`main` è attualmente **rotto**: un `SyntaxError` in `app.js` (codice changelog orfano rimasto dalla v1.5.2) impedisce l'esecuzione dello script → il sito resta bloccato sullo spinner. La produzione (`origin-01`) gira ancora un checkout vecchio ma valido, quindi **diverge** da `main`. Questa PR rimette `main` in uno stato valido e deployabile.

## Cosa cambia

- **fix(app.js)** — rimosso il blocco changelog orfano (causa del syntax error) + handler `beforeunload` duplicato. Ripristinato il fallback `augmented.json → audiobooks.json` che la produzione ha e `main` aveva perso.
- **refactor(css)** — 9 fogli di stile (incl. un "finto Tailwind" senza build e ~1100 righe morte) consolidati in **un solo `app.css`** guidato da design token (scale spazio/tipo/raggio/ombra/motion). Corretto il `font-size: 2rem` sul `<body>`. Reso visivamente identico (verificato nel browser, dark + mobile).
- **chore(sw)** — service worker saltato su localhost (no cache-first stantio in dev) + bump cache `v3 → v4` con asset list aggiornata.
- **chore(deploy)** — `deploy.sh` resiliente (lock, ff-only, validazione `node --check`/JSON, rollback) + unit systemd per auto-pull.

## Test

- [x] `node --check app.js` ✅
- [x] Render verificato in locale (header, ricerca, 10 generi, card featured) — 0 errori console
- [x] Dark + mobile

## Deploy (dopo il merge, su origin-01)

Il checkout del server diverge → **una tantum**:
```bash
FORCE_RESET=1 ./deploy.sh    # riallinea il checkout a origin/main
```
Poi `./deploy.sh` normale (o abilita il timer systemd). Consigliato `apt install -y nodejs` così il gate di validazione JS è attivo.

> Nota: questo NON include ancora la Netflix UI / SEO — è la base pulita. Quelle arrivano sul branch dopo.