### PR TITLE
Fix syntax error by removing stray closing brace

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -103,7 +103,6 @@ module.exports = {
         },
       },
     },
-  },
   plugins: [
     require('./tailwind-mobile-plugin.js'),
   ],


### PR DESCRIPTION
### FabGPT — code quality

**File:** `tailwind.config.js`

**Rationale:** The Tailwind config contains an extra closing brace before the plugins array, causing a syntax error that prevents the build from running. Removing the stray brace restores valid JavaScript syntax and ensures the configuration is loaded correctly.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `gpt-oss-120b` · task `41cdaf1e7fe5b2a7` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"41cdaf1e7fe5b2a7","source":"quality","model":"gpt-oss-120b","severity":"INFO","iterations":1,"inference_s":20.75,"prompt_sha":"efcddd9b710b33af","triage":"INFO"} -->